### PR TITLE
Add macOS 10.13 name "High Sierra"

### DIFF
--- a/www/constants.js
+++ b/www/constants.js
@@ -246,6 +246,7 @@ var OSXNameMap = {
   '10.10': 'Yosemite',
   '10.11': 'El Capitan',
   '10.12': 'Sierra',
+  '10.13': 'High Sierra',
 };
 
 function DarwinVersionToOSX(darwin_version)


### PR DESCRIPTION
Apparently 0.1% of our Mac users are already using it, and currently it shows up as "undefined".