### PR TITLE
Missing breakdown charts for 10.12 and 10.13

### DIFF
--- a/www/chart-graphs.js
+++ b/www/chart-graphs.js
@@ -840,7 +840,7 @@ ChartDisplay.prototype.drawMacStats = function ()
     return 'Unknown';
   }));
 
-  for (var i = 6; i <= 11; i++) {
+  for (var i = 6; i <= 13; i++) {
     var osx_version = '10.' + i;
     var elt = this.prepareChartDiv(
       'osx-' + osx_version,


### PR DESCRIPTION
We weren't showing the breakdown individual charts for Sierra and High Sierra